### PR TITLE
fix typing_extensions exception in experimental spark api

### DIFF
--- a/tools/pythonpkg/duckdb/experimental/spark/exception.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/exception.py
@@ -5,5 +5,11 @@ class ContributionsAcceptedError(NotImplementedError):
     feel free to open up a PR or a Discussion over on https://github.com/duckdb/duckdb
     """
 
+    def __init__(self, message=None):
+        doc = self.__class__.__doc__
+        if message:
+            doc = message + '\n' + doc
+        super().__init__(doc)
+
 
 __all__ = ["ContributionsAcceptedError"]

--- a/tools/pythonpkg/duckdb/experimental/spark/sql/_typing.py
+++ b/tools/pythonpkg/duckdb/experimental/spark/sql/_typing.py
@@ -25,7 +25,10 @@ from typing import (
     TypeVar,
     Union,
 )
-from typing_extensions import Literal, Protocol
+try:
+    from typing import Literal, Protocol
+except ImportError:
+    from typing_extensions import Literal, Protocol
 
 import datetime
 import decimal


### PR DESCRIPTION
`typing_extensions` is an optional module that can be installed, but in 3.8+ we don't need it anyway, so only fall back on <3.7