### PR TITLE
fix(python): minimal changes to support compiling for python 3.12

### DIFF
--- a/tools/pythonpkg/setup.py
+++ b/tools/pythonpkg/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
+import logging
 import os
 import sys
 import platform
@@ -102,9 +102,12 @@ def parallel_cpp_compile(
 
 # speed up compilation with: -j = cpu_number() on non Windows machines
 if os.name != 'nt' and os.environ.get('DUCKDB_DISABLE_PARALLEL_COMPILE', '') != '1':
-    import distutils.ccompiler
-
-    distutils.ccompiler.CCompiler.compile = parallel_cpp_compile
+    try:
+        from pybind11.setup_helpers import ParallelCompile
+    except ImportError:
+        logging.warning('Pybind11 not available yet')
+    else:
+        ParallelCompile().install()
 
 
 def open_utf8(fpath, flags):

--- a/tools/pythonpkg/src/numpy/numpy_scan.cpp
+++ b/tools/pythonpkg/src/numpy/numpy_scan.cpp
@@ -399,10 +399,6 @@ void NumpyScan::Scan(PandasColumnBindData &bind_data, idx_t count, idx_t offset,
 						throw NotImplementedException(
 						    "Unsupported typekind constant %d for Python Unicode Compact decode", kind);
 					}
-				} else if (ascii_obj->state.kind == PyUnicode_WCHAR_KIND) {
-					throw InvalidInputException("Unsupported: decode not ready legacy string");
-				} else if (!PyUtil::PyUnicodeIsCompact(unicode_obj) && ascii_obj->state.kind != PyUnicode_WCHAR_KIND) {
-					throw InvalidInputException("Unsupported: decode ready legacy string");
 				} else {
 					throw InvalidInputException("Unsupported string type: no clue what this string is");
 				}


### PR DESCRIPTION
This doesn't include any of the changes required for *us* to build wheels, just for upstreams (eg, conda, and end users on their machines).

In short, Python 3.12 support has been a real pain