### PR TITLE
test(python): fix blind catches

### DIFF
--- a/tools/pythonpkg/tests/conftest.py
+++ b/tools/pythonpkg/tests/conftest.py
@@ -89,9 +89,8 @@ class NumpyPandas:
         self.DataFrame = numpy_pandas_df
         self.pandas = pytest.importorskip("pandas")
 
-    def __getattr__(self, __name: str):
-        item = eval(f'self.pandas.{__name}')
-        return item
+    def __getattr__(self, name: str):
+        return getattr(self.pandas, name)
 
 
 def convert_arrow_to_numpy_backend(df):
@@ -125,9 +124,8 @@ class ArrowMockTesting:
         self.testing = pytest.importorskip("pandas").testing
         self.assert_frame_equal = convert_and_equal
 
-    def __getattr__(self, __name: str):
-        item = eval(f'self.testing.{__name}')
-        return item
+    def __getattr__(self, name: str):
+        return getattr(self.testing, name)
 
 
 # This converts dataframes constructed with 'DataFrame(...)' to pyarrow backed dataframes
@@ -145,9 +143,8 @@ class ArrowPandas:
             self.DataFrame = self.pandas.DataFrame
         self.testing = ArrowMockTesting()
 
-    def __getattr__(self, __name: str):
-        item = eval(f'self.pandas.{__name}')
-        return item
+    def __getattr__(self, name: str):
+        return getattr(self.pandas, name)
 
 
 @pytest.fixture(scope="function")

--- a/tools/pythonpkg/tests/conftest.py
+++ b/tools/pythonpkg/tests/conftest.py
@@ -4,12 +4,18 @@ import shutil
 from os.path import abspath, join, dirname, normpath
 import glob
 import duckdb
+import warnings
+from importlib import import_module
 
 try:
-    import pandas
+    # need to ignore warnings that might be thrown deep inside pandas's import tree (from dateutil in this case)
+    warnings.simplefilter(action='ignore', category=DeprecationWarning)
+    pandas = import_module('pandas')
+    warnings.resetwarnings()
 
     pyarrow_dtype = pandas.ArrowDtype
 except ImportError:
+    pandas = None
     pyarrow_dtype = None
 
 # Check if pandas has arrow dtypes enabled
@@ -19,6 +25,13 @@ try:
     pyarrow_dtypes_enabled = not pa_version_under7p0
 except ImportError:
     pyarrow_dtypes_enabled = False
+
+
+def import_pandas():
+    if pandas:
+        return pandas
+    else:
+        pytest.skip("Couldn't import pandas")
 
 
 # https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option
@@ -57,9 +70,8 @@ def duckdb_empty_cursor(request):
 
 def pandas_2_or_higher():
     from packaging.version import Version
-    import pandas as pd
 
-    return Version(pd.__version__) >= Version('2.0.0')
+    return Version(import_pandas().__version__) >= Version('2.0.0')
 
 
 def pandas_supports_arrow_backend():
@@ -68,14 +80,13 @@ def pandas_supports_arrow_backend():
 
         if pa_version_under7p0 == True:
             return False
-    except:
+    except ImportError:
         return False
     return pandas_2_or_higher()
 
 
 def numpy_pandas_df(*args, **kwargs):
-    pandas = pytest.importorskip("pandas")
-    return pandas.DataFrame(*args, **kwargs)
+    return import_pandas().DataFrame(*args, **kwargs)
 
 
 def arrow_pandas_df(*args, **kwargs):
@@ -87,20 +98,19 @@ class NumpyPandas:
     def __init__(self):
         self.backend = 'numpy_nullable'
         self.DataFrame = numpy_pandas_df
-        self.pandas = pytest.importorskip("pandas")
+        self.pandas = import_pandas()
 
     def __getattr__(self, name: str):
         return getattr(self.pandas, name)
 
 
 def convert_arrow_to_numpy_backend(df):
-    pandas = pytest.importorskip("pandas")
     names = df.columns
     df_content = {}
     for name in names:
         df_content[name] = df[name].array.__arrow_array__()
     # This should convert the pyarrow chunked arrays into numpy arrays
-    return pandas.DataFrame(df_content)
+    return import_pandas().DataFrame(df_content)
 
 
 def convert_to_numpy(df):
@@ -116,12 +126,12 @@ def convert_to_numpy(df):
 def convert_and_equal(df1, df2, **kwargs):
     df1 = convert_to_numpy(df1)
     df2 = convert_to_numpy(df2)
-    pytest.importorskip("pandas").testing.assert_frame_equal(df1, df2, **kwargs)
+    import_pandas().testing.assert_frame_equal(df1, df2, **kwargs)
 
 
 class ArrowMockTesting:
     def __init__(self):
-        self.testing = pytest.importorskip("pandas").testing
+        self.testing = import_pandas().testing
         self.assert_frame_equal = convert_and_equal
 
     def __getattr__(self, name: str):
@@ -133,7 +143,7 @@ class ArrowMockTesting:
 # this is done because we don't produce pyarrow backed dataframes yet
 class ArrowPandas:
     def __init__(self):
-        self.pandas = pytest.importorskip("pandas")
+        self.pandas = import_pandas()
         if pandas_2_or_higher() and pyarrow_dtypes_enabled:
             self.backend = 'pyarrow'
             self.DataFrame = arrow_pandas_df

--- a/tools/pythonpkg/tests/conftest.py
+++ b/tools/pythonpkg/tests/conftest.py
@@ -9,7 +9,7 @@ try:
     import pandas
 
     pyarrow_dtype = pandas.ArrowDtype
-except:
+except ImportError:
     pyarrow_dtype = None
 
 # Check if pandas has arrow dtypes enabled
@@ -17,7 +17,7 @@ try:
     from pandas.compat import pa_version_under7p0
 
     pyarrow_dtypes_enabled = not pa_version_under7p0
-except:
+except ImportError:
     pyarrow_dtypes_enabled = False
 
 

--- a/tools/pythonpkg/tests/conftest.py
+++ b/tools/pythonpkg/tests/conftest.py
@@ -13,7 +13,7 @@ try:
     pandas = import_module('pandas')
     warnings.resetwarnings()
 
-    pyarrow_dtype = getattr(pandas, 'ArrowDtype')
+    pyarrow_dtype = getattr(pandas, 'ArrowDtype', None)
 except ImportError:
     pandas = None
     pyarrow_dtype = None

--- a/tools/pythonpkg/tests/conftest.py
+++ b/tools/pythonpkg/tests/conftest.py
@@ -13,7 +13,7 @@ try:
     pandas = import_module('pandas')
     warnings.resetwarnings()
 
-    pyarrow_dtype = pandas.ArrowDtype
+    pyarrow_dtype = getattr(pandas, 'ArrowDtype')
 except ImportError:
     pandas = None
     pyarrow_dtype = None

--- a/tools/pythonpkg/tests/fast/adbc/test_connection_get_info.py
+++ b/tools/pythonpkg/tests/fast/adbc/test_connection_get_info.py
@@ -4,13 +4,14 @@ import duckdb
 import pytest
 
 pa = pytest.importorskip("pyarrow")
+adbc_driver_manager = pytest.importorskip("adbc_driver_manager")
 
 try:
     adbc_driver_duckdb = pytest.importorskip("adbc_driver_duckdb.dbapi")
     con = adbc_driver_duckdb.connect()
-except ImportError:
+except adbc_driver_manager.InternalError as e:
     pytest.skip(
-        "'duckdb_adbc_init' was not exported in this install, try running 'python3 setup.py install'.",
+        f"'duckdb_adbc_init' was not exported in this install, try running 'python3 setup.py install': {e}",
         allow_module_level=True,
     )
 

--- a/tools/pythonpkg/tests/fast/adbc/test_connection_get_info.py
+++ b/tools/pythonpkg/tests/fast/adbc/test_connection_get_info.py
@@ -5,8 +5,14 @@ import pytest
 
 pa = pytest.importorskip("pyarrow")
 
-adbc_driver_duckdb = pytest.importorskip("adbc_driver_duckdb.dbapi")
-con = adbc_driver_duckdb.connect()
+try:
+    adbc_driver_duckdb = pytest.importorskip("adbc_driver_duckdb.dbapi")
+    con = adbc_driver_duckdb.connect()
+except ImportError:
+    pytest.skip(
+        "'duckdb_adbc_init' was not exported in this install, try running 'python3 setup.py install'.",
+        allow_module_level=True,
+    )
 
 
 class TestADBCConnectionGetInfo(object):

--- a/tools/pythonpkg/tests/fast/sqlite/test_types.py
+++ b/tools/pythonpkg/tests/fast/sqlite/test_types.py
@@ -206,7 +206,7 @@ class DateTimeTests(unittest.TestCase):
         self.assertEqual(ts, ts2)
 
     def test_CheckSqlTimestamp(self):
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.UTC) if hasattr(datetime, 'UTC') else datetime.datetime.utcnow()
         self.cur.execute("insert into test(ts) values (current_timestamp)")
         self.cur.execute("select ts from test")
         ts = self.cur.fetchone()[0]

--- a/tools/pythonpkg/tests/fast/test_multithread.py
+++ b/tools/pythonpkg/tests/fast/test_multithread.py
@@ -11,7 +11,7 @@ try:
     import pyarrow as pa
 
     can_run = True
-except:
+except ImportError:
     can_run = False
 
 

--- a/tools/pythonpkg/tests/fast/test_non_default_conn.py
+++ b/tools/pythonpkg/tests/fast/test_non_default_conn.py
@@ -32,7 +32,7 @@ class TestNonDefaultConn(object):
     def test_from_parquet(self, duckdb_cursor):
         try:
             import pyarrow as pa
-        except:
+        except ImportError:
             return
         temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
         conn = duckdb.connect()

--- a/tools/pythonpkg/tests/fast/test_relation_dependency_leak.py
+++ b/tools/pythonpkg/tests/fast/test_relation_dependency_leak.py
@@ -7,7 +7,7 @@ try:
     import pyarrow as pa
 
     can_run = True
-except:
+except ImportError:
     can_run = False
 from conftest import NumpyPandas, ArrowPandas
 


### PR DESCRIPTION
This PR fixes several issues that came about by the use of "blind catches" in the Python tests that I undercovered working to add Py3.12 support